### PR TITLE
update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/node-honeycomb/hc-boilerplate#readme",
   "dependencies": {
     "hc-bee": "^0.0.4",
-    "lodash": "4.17.4"
+    "lodash": "4.17.14"
   },
   "devDependencies": {
     "mocha": "^5.0.0",


### PR DESCRIPTION
Update lodash from 4.17.4 to 4.17.14 which fixed prototype pollution
refer to:[https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/](url)