### PR TITLE
update simple tpl lodash from 4.17.4 to 4.17.14

### DIFF
--- a/simple/package.json
+++ b/simple/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/node-honeycomb/hc-boilerplate#readme",
   "dependencies": {
     "hc-bee": "^0.1.9",
-    "lodash": "4.17.4"
+    "lodash": "4.17.14"
   },
   "devDependencies": {
     "api-annotation": "^1.0.2",


### PR DESCRIPTION
Update simple tpl lodash from 4.17.4 to 4.17.14 which fixed prototype pollution
refer to:https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/